### PR TITLE
Removed the windows1252 message, refactored the auto detect itself to work as atom's one fixed #1

### DIFF
--- a/lib/auto-encoding.coffee
+++ b/lib/auto-encoding.coffee
@@ -17,10 +17,8 @@ class AutoEncoding
     # convert text
     return fs.readFile filePath, (error, buffer) =>
       return if error?
-
       {encoding} =  jschardet.detect(buffer) ? {}
       encoding = 'utf8' if encoding is 'ascii'
       return unless iconv.encodingExists(encoding)
-
       encoding = encoding.toLowerCase().replace(/[^0-9a-z]|:\d{4}$/g, '')
       @editor.setEncoding(encoding)

--- a/lib/auto-encoding.coffee
+++ b/lib/auto-encoding.coffee
@@ -12,22 +12,15 @@ class AutoEncoding
 
     # get file path
     filePath = @editor.getPath()
-    return if not fs.existsSync filePath
+    return unless fs.existsSync(filePath)
 
     # convert text
-    return fs.readFile(
-      filePath,
-      (error, buffer) =>
-        return if error isnt null
-        enc = (if (_ref = jschardet.detect buffer)? then _ref else {}).encoding
-        enc = 'utf8' if enc is 'ascii'
-        return if not iconv.encodingExists enc
-        enc = enc.toLowerCase().replace /[^0-9a-z]|:\d{4}$/g, ''
-        nowEnc = @editor?.getEncoding() ? ''
-        if not new RegExp('^'+enc+'$', 'i').test nowEnc
+    return fs.readFile filePath, (error, buffer) =>
+      return if error?
 
-          if atom.config.get 'auto-encoding.warningWindows1252'
-            atom.notifications?.addWarning 'change encoding to windows1252'
+      {encoding} =  jschardet.detect(buffer) ? {}
+      encoding = 'utf8' if encoding is 'ascii'
+      return unless iconv.encodingExists(encoding)
 
-          @editor?.setEncoding(enc)
-    )
+      encoding = encoding.toLowerCase().replace(/[^0-9a-z]|:\d{4}$/g, '')
+      @editor.setEncoding(encoding)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,7 +10,7 @@ module.exports = Main =
       title: 'Always auto detect'
       description: 'enabled from startup'
       type: 'boolean'
-      default: false
+      default: true
 
   activate: ->
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -11,10 +11,6 @@ module.exports = Main =
       description: 'enabled from startup'
       type: 'boolean'
       default: false
-    warningWindows1252:
-      title: 'Show warning message when change encoding to "windows1252".'
-      type: 'boolean'
-      default: false
 
   activate: ->
 


### PR DESCRIPTION
I figured out what williamokano meant on the issue #1  . He wasn't able to auto detect files when they needed to be on windows1252. As far as I know the package is to automatically detect the encoding of my files, not tell me to encode to something... So I removed this feature and enabled auto-decoding as ON since many users wont see this setup as long they download this package for this feature only.

Also I've worked out to do exactly what atom does, so we are free of uncommon errors.
