### PR TITLE
Window:Reloadでも自動判定が効くように

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -38,7 +38,7 @@ module.exports = Main =
     @enc ?= new AutoEncoding()
 
     # event: open file
-    @subscriptions.add atom.workspace.onDidOpen => @enc.fire()
+    @subscriptions.add atom.workspace.observeTextEditors => @enc.fire()
     # event: changed active pane
     @subscriptions.add atom.workspace.onDidChangeActivePaneItem => @enc.fire()
 


### PR DESCRIPTION
例えばSJISのファイルを開いたままWindow：Reloadすると、再オープン時に自動判定が効かないようです。
